### PR TITLE
drop python 3 7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - "--py37-plus"
+          - "--py39-plus"
           - "--keep-runtime-typing"
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `pyupgrade` hook to enhance compatibility with Python 3.9 and newer versions, ensuring more efficient code upgrades while maintaining runtime typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->